### PR TITLE
Prevent converting functions that declare this parameters

### DIFF
--- a/src/guard.ts
+++ b/src/guard.ts
@@ -161,32 +161,18 @@ export class Guard {
 
     const [firstParam] = fn.params;
 
-    const getIdentifier = (param: TSESTree.Parameter): TSESTree.Identifier | null => {
-      if (param.type === AST_NODE_TYPES.Identifier) {
-        return param;
-      }
+    if (firstParam.type === AST_NODE_TYPES.Identifier) {
+      return firstParam.name === 'this';
+    }
 
-      if (param.type === AST_NODE_TYPES.AssignmentPattern && param.left.type === AST_NODE_TYPES.Identifier) {
-        return param.left;
-      }
+    if (
+      firstParam.type === AST_NODE_TYPES.TSParameterProperty &&
+      firstParam.parameter.type === AST_NODE_TYPES.Identifier
+    ) {
+      return firstParam.parameter.name === 'this';
+    }
 
-      if (param.type === AST_NODE_TYPES.RestElement && param.argument.type === AST_NODE_TYPES.Identifier) {
-        return param.argument;
-      }
-
-      if (
-        param.type === AST_NODE_TYPES.TSParameterProperty &&
-        param.parameter.type === AST_NODE_TYPES.Identifier
-      ) {
-        return param.parameter;
-      }
-
-      return null;
-    };
-
-    const identifier = getIdentifier(firstParam);
-
-    return identifier?.name === 'this';
+    return false;
   }
 
   containsTokenSequence(sequence: [string, string][], node: TSESTree.Node): boolean {

--- a/test/rule.spec.ts
+++ b/test/rule.spec.ts
@@ -143,6 +143,12 @@ describe('when function is already an arrow function, or cannot be converted to 
         {
           code: 'function Foo() {if (!new.target) throw "Foo() must be called with new";}',
         },
+        {
+          code: 'function withThis(this: HTMLElement, event: Event) { return event.type; }',
+        },
+        {
+          code: 'const withThis = function(this: void, value: number) { return value; };',
+        },
         // assertion functions are unavailable in arrow functions
         {
           code: 'function foo(val: any): asserts val is string {}',


### PR DESCRIPTION
## Summary
- skip transforming functions that declare `this` as their first parameter to avoid generating invalid arrow functions
- cover functions with `this` parameters in the valid rule tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68cf9aa99d28832286a89c715775f75c